### PR TITLE
[Bug Fix] Address a potential bug in `DataLoader` and unittests.

### DIFF
--- a/PyCytoData/data.py
+++ b/PyCytoData/data.py
@@ -867,6 +867,7 @@ class DataLoader():
             sample = np.array(sample).flatten()
             
         all_files = glob.glob(cls._data_path[dataset]+dataset+"*.txt")
+        print(all_files)
         files: List[str] = []
         metadata_files: List[str] = []
         for f in all_files:
@@ -878,7 +879,10 @@ class DataLoader():
         if sample is not None:
             r = re.compile("(.*" + ".*)|(.*".join(sample) + ".*)")
             files = list(filter(r.match, files))
-            metadata_files = list(filter(r.match, metadata_files))         
+            metadata_files = list(filter(r.match, metadata_files))  
+            
+        print(files)
+        print(metadata_files)       
             
         data: PyCytoData = FileIO.load_expression(files=files, col_names = True)
         metadata: Optional[np.ndarray] = None

--- a/PyCytoData/data.py
+++ b/PyCytoData/data.py
@@ -868,7 +868,6 @@ class DataLoader():
             
         all_files = glob.glob(cls._data_path[dataset]+dataset+"*.txt")
         all_files = sorted(all_files)
-        print(all_files)
         files: List[str] = []
         metadata_files: List[str] = []
         for f in all_files:
@@ -880,10 +879,7 @@ class DataLoader():
         if sample is not None:
             r = re.compile("(.*" + ".*)|(.*".join(sample) + ".*)")
             files = list(filter(r.match, files))
-            metadata_files = list(filter(r.match, metadata_files))  
-            
-        print(files)
-        print(metadata_files)       
+            metadata_files = list(filter(r.match, metadata_files))   
             
         data: PyCytoData = FileIO.load_expression(files=files, col_names = True)
         metadata: Optional[np.ndarray] = None

--- a/PyCytoData/data.py
+++ b/PyCytoData/data.py
@@ -867,6 +867,7 @@ class DataLoader():
             sample = np.array(sample).flatten()
             
         all_files = glob.glob(cls._data_path[dataset]+dataset+"*.txt")
+        all_files = sorted(all_files)
         print(all_files)
         files: List[str] = []
         metadata_files: List[str] = []

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -758,12 +758,7 @@ class TestDataLoader():
                                                           "levine32": "./tmp_pytest/data/" + "levine32/",
                                                           "samusik": "./tmp_pytest/data/" + "samusik/"})
         
-        dataset = "levine13"
-        df = FileIO.load_expression("./tmp_pytest/data/"+ dataset + "/" + dataset +"_01.txt")
-        print(df.expression_matrix)
-        
         data: PyCytoData = DataLoader.load_dataset(dataset="levine13", preprocess=True)
-        print(data.expression_matrix)
         assert isinstance(data, PyCytoData)
         assert np.isclose(data.expression_matrix[0,0], np.arcsinh(4.4/5))
        

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -698,6 +698,7 @@ class TestDataLoader():
             if dataset == "levine13":
                 levine13: np.ndarray = np.random.rand(2, cls.n_channels[dataset])
                 levine13[0,0] = 4.4
+                print(levine13)
                 FileIO.save_np_array(levine13, exprs_path_01, channels)
             else:
                 FileIO.save_np_array(np.random.rand(2, cls.n_channels[dataset]), exprs_path_01, channels)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -708,6 +708,11 @@ class TestDataLoader():
             FileIO.save_np_array(np.array([["B", "02"],["A", "02"]]), types_path_02, dtype="%s")
         
         
+    def test_saved_array(self):
+        dataset = "levine13"
+        df = FileIO.load_expression("./tmp_pytest/data/"+ dataset + "/" + dataset +"_01.txt")
+        print(df.expression_matrix)
+        
     def test_load_dataset_value_error(self):        
         try:
             DataLoader.load_dataset(dataset="levine14")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -758,6 +758,10 @@ class TestDataLoader():
                                                           "levine32": "./tmp_pytest/data/" + "levine32/",
                                                           "samusik": "./tmp_pytest/data/" + "samusik/"})
         
+        dataset = "levine13"
+        df = FileIO.load_expression("./tmp_pytest/data/"+ dataset + "/" + dataset +"_01.txt")
+        print(df.expression_matrix)
+        
         data: PyCytoData = DataLoader.load_dataset(dataset="levine13", preprocess=True)
         print(data.expression_matrix)
         assert isinstance(data, PyCytoData)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -708,11 +708,6 @@ class TestDataLoader():
             FileIO.save_np_array(np.array([["B", "02"],["A", "02"]]), types_path_02, dtype="%s")
         
         
-    def test_saved_array(self):
-        dataset = "levine13"
-        df = FileIO.load_expression("./tmp_pytest/data/"+ dataset + "/" + dataset +"_01.txt")
-        print(df.expression_matrix)
-        
     def test_load_dataset_value_error(self):        
         try:
             DataLoader.load_dataset(dataset="levine14")


### PR DESCRIPTION
This PR addresses the following issues:

- The `DataLoader.load_dataset` method may switch orders of samples when multiple samples are present.

While the above issue has been an implementation detail, we should keep this as consistent as possible as newer versions of Python broke CI. Now, the samples are sorted. However, we do not guarantee this behavior as of now.