### PR TITLE
[Bug Fix] Fix loading of mismatched files (#7)

### DIFF
--- a/PyCytoData/data.py
+++ b/PyCytoData/data.py
@@ -1173,6 +1173,7 @@ class FileIO():
         :type dtype: type, optional
 
         :raises TypeError: The ``files`` is neither a string nor a list of strings.
+        :raises ValueError: The expression matrices' channels are mismatched or misaligned.
         :return: A PyCytoData object.
         :rtype: PyCytoData
         """
@@ -1194,6 +1195,19 @@ class FileIO():
             colnames = np.loadtxt(fname=files[0], dtype ="str", max_rows=1, delimiter=delim)
             if drop_columns is not None:
                 colnames = np.delete(colnames, drop_columns)
+                
+            # Check whether channels are aligned properly
+            if len(files) > 1:
+                f: int
+                for f in range(1, len(files)):
+                    temp_colnames: np.ndarray = np.loadtxt(fname=files[f], dtype ="str", max_rows=1, delimiter=delim)
+                    if drop_columns is not None:
+                        temp_colnames = np.delete(temp_colnames, drop_columns)
+                    if not np.all(temp_colnames == colnames):
+                        msg: str = f"The channels of expression matrices the first and {f+1}-th are not the same. "
+                        msg += "Please ensure expression matrices' channels are in the same order with the same channels."
+                        raise ValueError(msg)
+                    
         else:
             colnames = np.full(data.n_channels, None)
 

--- a/docs/source/tutorial/fileio.rst
+++ b/docs/source/tutorial/fileio.rst
@@ -190,8 +190,8 @@ Load Multiple Datasets at Once
 ------------------------------------
 
 If you have multiple samples in the same format (i.e. The columns are in the same
-configuration), you can load multiple samples at once into one single ``PyCytoData``
-object: 
+configuration after accounting for dropped columns as seen in the next section),
+you can load multiple samples at once into one single ``PyCytoData`` object: 
 
 .. code-block:: python
 
@@ -200,6 +200,9 @@ object:
     2
 
 All samples will be stored in a single object, but sample indices will be preserved.
+In the cases that channels are misaligned or mismatched, preprocessing on the users'
+side is needed to ensure that they are the same. Otherwise, a `ValueError` will be
+thrown. 
 
 Specifying Columns
 -------------------

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -897,6 +897,12 @@ class TestFileIO():
             tsv_writer.writerow([7, 8, 9])
             tsv_writer.writerow([10, 11, 12])
             
+        with open("./tmp_pytest/file_read_test_csv3.txt", "w") as f:
+            tsv_writer: "_csv._writer" = csv.writer(f, delimiter=",")
+            tsv_writer.writerow(["col3", "col2", "col1"])
+            tsv_writer.writerow([7, 8, 9])
+            tsv_writer.writerow([10, 11, 12])
+            
         with open("./tmp_pytest/file_read_test_tsv.txt", "w") as f:
             tsv_writer: "_csv._writer" = csv.writer(f, delimiter="\t")
             tsv_writer.writerow([1.1, 2.2, 3.3])
@@ -928,7 +934,26 @@ class TestFileIO():
         assert out_file.n_cells == 4
         assert out_file.n_channels == 3
         assert np.all(np.isin([0, 1], out_file.sample_index))
+        
+        
+    def test_laod_expression_mismatch_error(self):
+        try:
+            out_file: PyCytoData = FileIO.load_expression(["./tmp_pytest/file_read_test_csv2.txt", "./tmp_pytest/file_read_test_csv3.txt"],
+                                                          col_names=True, delim=",", dtype = int)
+        except ValueError as e:
+            msg: str = "The channels of expression matrices the first and 2-th are not the same. "
+            msg += "Please ensure expression matrices' channels are in the same order with the same channels."
+            assert msg in str(e)
+        else:
+            assert False
             
+            
+    def test_laod_expression_mismatch_drop(self):
+        out_file: PyCytoData = FileIO.load_expression(["./tmp_pytest/file_read_test_csv2.txt", "./tmp_pytest/file_read_test_csv3.txt"],
+                                                      col_names=True, delim=",", dtype = int, drop_columns=[0,2])
+        assert out_file.n_channels == 1
+        assert out_file.n_cells == 4
+    
     
     @pytest.mark.parametrize("drop_cols,expected_shape",
             [([0, 1], (2, 1)), (1, (2,2))]


### PR DESCRIPTION
In the previous release, there is a bug involving the `FileIO.load_expression()` method silently concatenating two expression matrices even when the column names are not the same. Now a `ValueError` is thrown when when two expression matrices are different in their channel configurations.

Note that we leave the ordering of channels to users for now: this means when all the same channels are present, we still throw an error as of now. We may add functionalities to address this in the future.